### PR TITLE
Build - Account for Node Modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Letterboxd-Extras.zip
 ff android debug.txt
 /src/dist
 *.zip
+/src/common/node_modules

--- a/src/build.bat
+++ b/src/build.bat
@@ -19,8 +19,7 @@ if exist "%DIST_DIR%" (
 )
 mkdir "%DIST_DIR%"
 
-:: Copy common files
-xcopy /e /i /y "%COMMON_DIR%" "%DIST_DIR%"
+ROBOCOPY "%COMMON_DIR%" "%DIST_DIR%" /E /XD "node_modules"
 
 :: Copy manifest
 copy /y "%TARGET_DIR%" "%DIST_DIR%"


### PR DESCRIPTION
Prevent node_modules from accidently being added in a PR. 